### PR TITLE
Adds generic SMTP driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": "^7.2|^8.0"
     },
     "conflict": {
         "itinerisltd/phpmailer-mailhog": "*",

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace Itineris\WPPHPMailer;
 
-use Itineris\WPPHPMailer\Drivers\SMTPDriver;
 use Itineris\WPPHPMailer\Drivers\MailHogDriver;
 use Itineris\WPPHPMailer\Drivers\MailtrapDriver;
 use Itineris\WPPHPMailer\Drivers\Office365Driver;
 use Itineris\WPPHPMailer\Drivers\SendGridDriver;
+use Itineris\WPPHPMailer\Drivers\SMTPDriver;
 use Itineris\WPPHPMailer\Exceptions\NotFoundException;
 
 class ConfigFactory
 {
     protected const DRIVERS = [
-        'smtp' => SMTPDriver::class,
         'mailhog' => MailHogDriver::class,
         'mailtrap' => MailtrapDriver::class,
         'office365' => Office365Driver::class,
         'sendgrid' => SendGridDriver::class,
+        'smtp' => SMTPDriver::class,
     ];
 
     /** @var array<string, string> */

--- a/src/Drivers/SMTPDriver.php
+++ b/src/Drivers/SMTPDriver.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Itineris\WPPHPMailer\Drivers;
+
+use Itineris\WPPHPMailer\Config;
+use Itineris\WPPHPMailer\ConfigInterface;
+use Itineris\WPPHPMailer\ConstantRepository;
+
+class SMTPDriver implements \Itineris\WPPHPMailer\Drivers\DriverInterface
+{
+    public static function makeConfig(ConstantRepository $constantRepo): ConfigInterface
+    {
+        $config = new Config();
+
+        $config->set(
+            'auth',
+            $constantRepo->get('SMTP_AUTH') ?: true
+        );
+
+        $config->set(
+            'host',
+            $constantRepo->getRequired('SMTP_HOST')
+        );
+
+        $config->set(
+            'port',
+            $constantRepo->get('SMTP_PORT') ?: 587
+        );
+
+        $config->set(
+            'protocol',
+            $constantRepo->get('SMTP_PROTOCOL') ?: 'tls'
+        );
+
+        $config->set(
+            'username',
+            $constantRepo->getRequired('SMTP_USERNAME')
+        );
+
+        $config->set(
+            'password',
+            $constantRepo->getRequired('SMTP_PASSWORD')
+        );
+
+        $config->set(
+            'fromAddress',
+            $constantRepo->get('SMTP_FROM_ADDRESS')
+        );
+
+        $config->set(
+            'fromName',
+            $constantRepo->get('SMTP_FROM_NAME')
+        );
+
+        $config->set(
+            'fromAuto',
+            $constantRepo->get('SMTP_FROM_AUTO')
+        );
+
+        return $config;
+    }
+}

--- a/src/Drivers/SMTPDriver.php
+++ b/src/Drivers/SMTPDriver.php
@@ -16,7 +16,7 @@ class SMTPDriver implements \Itineris\WPPHPMailer\Drivers\DriverInterface
 
         $config->set(
             'auth',
-            $constantRepo->get('SMTP_AUTH') ?: true
+            $constantRepo->get('SMTP_AUTH') ?? true
         );
 
         $config->set(
@@ -26,12 +26,12 @@ class SMTPDriver implements \Itineris\WPPHPMailer\Drivers\DriverInterface
 
         $config->set(
             'port',
-            $constantRepo->get('SMTP_PORT') ?: 587
+            $constantRepo->get('SMTP_PORT') ?? 587
         );
 
         $config->set(
             'protocol',
-            $constantRepo->get('SMTP_PROTOCOL') ?: 'tls'
+            $constantRepo->get('SMTP_PROTOCOL') ?? 'tls'
         );
 
         $config->set(

--- a/tests/unit/ConfigFactoryTest.php
+++ b/tests/unit/ConfigFactoryTest.php
@@ -30,7 +30,7 @@ class ConfigFactoryTest extends Unit
             ->once();
 
         WP_Mock::expectFilter('wp_phpmailer_drivers', [
-            'smtp' => SMTPDriver:class,
+            'smtp' => SMTPDriver::class,
             'mailhog' => MailHogDriver::class,
             'mailtrap' => MailtrapDriver::class,
             'office365' => Office365Driver::class,
@@ -55,7 +55,7 @@ class ConfigFactoryTest extends Unit
                      ->once();
 
         WP_Mock::expectFilter('wp_phpmailer_drivers', [
-            'smtp' => SMTPDriver:class,
+            'smtp' => SMTPDriver::class,
             'mailhog' => MailHogDriver::class,
             'mailtrap' => MailtrapDriver::class,
             'office365' => Office365Driver::class,

--- a/tests/unit/ConfigFactoryTest.php
+++ b/tests/unit/ConfigFactoryTest.php
@@ -37,7 +37,7 @@ class ConfigFactoryTest extends Unit
             'smtp' => SMTPDriver::class,
         ]);
 
-        $expected = new NotFoundException("Driver 'non-exist-driver' not found, acceptable values are: smtp, mailhog, mailtrap, office365, sendgrid");
+        $expected = new NotFoundException("Driver 'non-exist-driver' not found, acceptable values are: mailhog, mailtrap, office365, sendgrid, smtp");
 
         $this->tester->expectThrowable($expected, function () use ($constantRepo): void {
             ConfigFactory::make($constantRepo);

--- a/tests/unit/ConfigFactoryTest.php
+++ b/tests/unit/ConfigFactoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Itineris\WPPHPMailer;
 
 use Codeception\Test\Unit;
-use Itineris\WPPHPMailer\SMTPDriver;
+use Itineris\WPPHPMailer\Drivers\SMTPDriver;
 use Itineris\WPPHPMailer\Drivers\MailHogDriver;
 use Itineris\WPPHPMailer\Drivers\MailtrapDriver;
 use Itineris\WPPHPMailer\Drivers\Office365Driver;

--- a/tests/unit/ConfigFactoryTest.php
+++ b/tests/unit/ConfigFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Itineris\WPPHPMailer;
 
 use Codeception\Test\Unit;
+use Itineris\WPPHPMailer\SMTPDriver;
 use Itineris\WPPHPMailer\Drivers\MailHogDriver;
 use Itineris\WPPHPMailer\Drivers\MailtrapDriver;
 use Itineris\WPPHPMailer\Drivers\Office365Driver;
@@ -29,13 +30,14 @@ class ConfigFactoryTest extends Unit
             ->once();
 
         WP_Mock::expectFilter('wp_phpmailer_drivers', [
+            'smtp' => SMTPDriver:class,
             'mailhog' => MailHogDriver::class,
             'mailtrap' => MailtrapDriver::class,
             'office365' => Office365Driver::class,
             'sendgrid' => SendGridDriver::class,
         ]);
 
-        $expected = new NotFoundException("Driver 'non-exist-driver' not found, acceptable values are: mailhog, mailtrap, office365, sendgrid");
+        $expected = new NotFoundException("Driver 'non-exist-driver' not found, acceptable values are: smtp, mailhog, mailtrap, office365, sendgrid");
 
         $this->tester->expectThrowable($expected, function () use ($constantRepo): void {
             ConfigFactory::make($constantRepo);
@@ -53,6 +55,7 @@ class ConfigFactoryTest extends Unit
                      ->once();
 
         WP_Mock::expectFilter('wp_phpmailer_drivers', [
+            'smtp' => SMTPDriver:class,
             'mailhog' => MailHogDriver::class,
             'mailtrap' => MailtrapDriver::class,
             'office365' => Office365Driver::class,

--- a/tests/unit/ConfigFactoryTest.php
+++ b/tests/unit/ConfigFactoryTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Itineris\WPPHPMailer;
 
 use Codeception\Test\Unit;
-use Itineris\WPPHPMailer\Drivers\SMTPDriver;
 use Itineris\WPPHPMailer\Drivers\MailHogDriver;
 use Itineris\WPPHPMailer\Drivers\MailtrapDriver;
 use Itineris\WPPHPMailer\Drivers\Office365Driver;
 use Itineris\WPPHPMailer\Drivers\SendGridDriver;
+use Itineris\WPPHPMailer\Drivers\SMTPDriver;
 use Itineris\WPPHPMailer\Exceptions\NotFoundException;
 use Mockery;
 use WP_Mock;
@@ -30,11 +30,11 @@ class ConfigFactoryTest extends Unit
             ->once();
 
         WP_Mock::expectFilter('wp_phpmailer_drivers', [
-            'smtp' => SMTPDriver::class,
             'mailhog' => MailHogDriver::class,
             'mailtrap' => MailtrapDriver::class,
             'office365' => Office365Driver::class,
             'sendgrid' => SendGridDriver::class,
+            'smtp' => SMTPDriver::class,
         ]);
 
         $expected = new NotFoundException("Driver 'non-exist-driver' not found, acceptable values are: smtp, mailhog, mailtrap, office365, sendgrid");
@@ -55,11 +55,11 @@ class ConfigFactoryTest extends Unit
                      ->once();
 
         WP_Mock::expectFilter('wp_phpmailer_drivers', [
-            'smtp' => SMTPDriver::class,
             'mailhog' => MailHogDriver::class,
             'mailtrap' => MailtrapDriver::class,
             'office365' => Office365Driver::class,
             'sendgrid' => SendGridDriver::class,
+            'smtp' => SMTPDriver::class,
         ]);
 
         $expected = MailHogDriver::makeConfig($constantRepo);


### PR DESCRIPTION
This is such a useful and streight forward SMTP implementation. Thanks a lot for the package.
However I stumpled over it again and wondered another time, why there is no simple SMTP driver one can use with any SMTP compatible service. So I added one for my own and I am sure that this will be useful for others, too.

Thanks and kind regards,

Philipp

Closes #508 